### PR TITLE
クレジットテキストの自動記入機能の実装

### DIFF
--- a/OSM_AccessMap.js
+++ b/OSM_AccessMap.js
@@ -334,9 +334,9 @@ function saveImage(type) {
 	svg.AddIcons(marker);
 
 	let options = {};
-	options.vbx = svg.attr("viewBox").split(" ");
-	options.width = svg.width();
-	options.height = svg.height();
+	options.vbx = vbx;
+	options.width = width;
+	options.height = height;
 	options.stb = svg.attr("style");
 
 	svg.attr("style","");

--- a/index.html
+++ b/index.html
@@ -85,8 +85,8 @@
 					</div>
 					<div style="float: left; width: 45px; margin: 0px 0px 0px 0px;"><img  src="./image/Arrow_Right.png"></div>
 					<div id="export_area" style="float: left; width: 150px;position: absolute; top: 36px; right: 6px;">
-						<button id="save_png" class="export_button" onclick="savePNG()">PNG保存</button>
-						<button id="save_svg" class="export_button" onclick="saveSVG()">SVG保存</button>
+						<button id="save_png" class="export_button" onclick="saveImage('png')">PNG保存</button>
+						<button id="save_svg" class="export_button" onclick="saveImage('svg')">SVG保存</button>
 					</div>
 				</div>
 


### PR DESCRIPTION
作成した SVG 画像と PNG 画像に著作権表示のクレジットが画像の右下隅に自動で入るようにしました。併せて、共通部分のソースコードを整理しています。

クレジットのテキストは、[まち歩きマップメーカー](https://k-sakanoshita.github.io/OSM_AccessMap/) の下部に従って `Map data © OpenStreetMap` にしましたが、[JA:Legal FAQ](https://wiki.openstreetmap.org/wiki/JA:Legal_FAQ#3a._OpenStreetMap_.E3.81.AE.E3.83.9E.E3.83.83.E3.83.97.E3.82.92.E4.BD.BF.E3.81.84.E3.81.9F.E3.81.84.E3.81.AE.E3.81.A7.E3.81.99.E3.81.8C.E3.80.81.E3.81.A9.E3.81.AE.E3.82.88.E3.81.86.E3.81.AB.E3.82.AF.E3.83.AC.E3.82.B8.E3.83.83.E3.83.88.E8.A1.A8.E8.A8.98.E3.82.92.E3.81.97.E3.81.9F.E3.82.89.E8.89.AF.E3.81.84.E3.81.A7.E3.81.99.E3.81.8B.EF.BC.9F) によると `Map data © OpenStreetMap contributors` の方が適切なような気もします。